### PR TITLE
Fix: This solver needs samples of at least 2 classes

### DIFF
--- a/models/train_classifier.py
+++ b/models/train_classifier.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from sklearn.datasets import make_multilabel_classification
 from sklearn.multioutput import MultiOutputClassifier
-from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.pipeline import Pipeline
 from sklearn.metrics import confusion_matrix
 from sklearn.metrics import classification_report
@@ -56,7 +56,7 @@ def tokenize(text):
 
 
 def build_model():
-    lr  = LogisticRegression()
+    lr  = RandomForestClassifier()
 
     # build pipeline
     pipeline = Pipeline([('vect', CountVectorizer(tokenizer=tokenize)),


### PR DESCRIPTION
If you try to look at the number of classes in each category, you will find that one such category exists where there is only one class (child_alone).

![Disaster-Response-Pipeline_—_-zsh_—_126×34](https://github.com/yu-huai-lin/Disaster-Response-Pipeline/assets/18123459/6df7e953-cb30-4663-8e9b-dbb45d9fb32f)

Logistic regression does not work on data having a single class target variable. It needs at least two classes to initiate the fitting operation.

To resolve this issue, you can use ensemble models such as RandomForest, Adaboost etc.

